### PR TITLE
Support restoring an account without restarting havenod

### DIFF
--- a/src/HavenoClient.test.ts
+++ b/src/HavenoClient.test.ts
@@ -235,6 +235,7 @@ test("Can manage an account", async () => {
   let charlie: HavenoClient | undefined;
   let err: any;
   try {
+
     // start charlie without opening account
     charlie = await initHaveno({autoLogin: false});
     assert(!await charlie.accountExists());
@@ -248,6 +249,7 @@ test("Can manage an account", async () => {
     if (await charlie.isConnectedToMonero()) await charlie.getBalances(); // only connected if local node running
     assert(await charlie.accountExists());
     assert(await charlie.isAccountOpen());
+
     // create payment account
     const paymentAccount = await charlie.createCryptoPaymentAccount("My ETH account", TestConfig.cryptoAddresses[0].currencyCode, TestConfig.cryptoAddresses[0].address);
     

--- a/src/HavenoClient.ts
+++ b/src/HavenoClient.ts
@@ -325,7 +325,7 @@ export default class HavenoClient {
   }
   
   /**
-   * Permanently delete the Haveno account and shutdown the server. // TODO: possible to not shutdown server?
+   * Permanently delete the Haveno account.
    */
   async deleteAccount(): Promise<void> {
     return new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
Test updates for haveno-dex/haveno#310.

Updated 'Can manage an account` test so that delete and restore account does not restart the havenod process.

I had issues with this [line](https://github.com/haveno-dex/haveno-ts/blob/f9bbee87268ab314949dc363f3d5d6f72d75aa90/src/HavenoClient.test.ts#L249) in the test so I ran it with that line commented out before any changes were made. It was throwing `RpcError: wallet and network is not yet initialized Error: wallet and network is not yet initialized`.