### PR TITLE
Filter private fields from tsdoc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "monero-javascript": "^0.7.4",
         "typedoc": "^0.22.15",
         "typedoc-plugin-missing-exports": "^0.22.6",
+        "typedoc-plugin-regex-filter": "^0.0.1",
         "typedoc-plugin-rename-defaults": "^0.5.1",
         "typescript": "^4.6.4"
       }
@@ -13686,6 +13687,15 @@
         "typedoc": "0.22.x"
       }
     },
+    "node_modules/typedoc-plugin-regex-filter": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-regex-filter/-/typedoc-plugin-regex-filter-0.0.1.tgz",
+      "integrity": "sha512-aYPoTYMDO0REGGOqtZdJ/YGMu21og4aWOmf0l/o7qQDs6xDJfvp3v0jnBL8IigiDUapOpog83IDS92fyUsFobQ==",
+      "dev": true,
+      "peerDependencies": {
+        "typedoc": "0.22.x"
+      }
+    },
     "node_modules/typedoc-plugin-rename-defaults": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/typedoc-plugin-rename-defaults/-/typedoc-plugin-rename-defaults-0.5.1.tgz",
@@ -24619,6 +24629,13 @@
       "version": "0.22.6",
       "resolved": "https://registry.npmjs.org/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-0.22.6.tgz",
       "integrity": "sha512-1uguGQqa+c5f33nWS3v1mm0uAx4Ii1lw4Kx2zQksmYFKNEWTmrmMXbMNBoBg4wu0p4dFCNC7JIWPoRzpNS6pFA==",
+      "dev": true,
+      "requires": {}
+    },
+    "typedoc-plugin-regex-filter": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-regex-filter/-/typedoc-plugin-regex-filter-0.0.1.tgz",
+      "integrity": "sha512-aYPoTYMDO0REGGOqtZdJ/YGMu21og4aWOmf0l/o7qQDs6xDJfvp3v0jnBL8IigiDUapOpog83IDS92fyUsFobQ==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "jest",
     "eslint": "eslint .",
     "eslintfix": "eslint src/* --fix",
-    "typedoc": "typedoc ./src/index.ts --entryPointStrategy expand src/ --exclude **/*.test.ts"
+    "typedoc": "typedoc ./src/index.ts --entryPointStrategy expand src/ --exclude **/*.test.ts --excludePrivate"
   },
   "jest": {
     "testPathIgnorePatterns": ["<rootDir>/dist/", "/node_modules/"]
@@ -52,6 +52,7 @@
     "typedoc": "^0.22.15",
     "typedoc-plugin-missing-exports": "^0.22.6",
     "typedoc-plugin-rename-defaults": "^0.5.1",
+    "typedoc-plugin-regex-filter": "^0.0.1",
     "typescript": "^4.6.4"
   }
 }


### PR DESCRIPTION
Hello, I created NPM package `typedoc-plugin-regex-filter` to filter out fields and methods based on regular expression.
Default filtering value is by `_` prefix so it matches the requirements of haveno-ts.

This PR fixes #139